### PR TITLE
update dependency config for npm 3+

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "author": "https://github.com/bbraithwaite",
   "license": "ISC",
-  "peerDependencies": {
-          "eslint": ">= 3"
+  "dependencies": {
+      "eslint": ">= 3"
   }
 }


### PR DESCRIPTION
From npm 3, peerDependencies is no longer supported.