### PR TITLE
Try fixing eslint dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "author": "https://github.com/bbraithwaite",
   "license": "ISC",
   "dependencies": {
-      "eslint": ">= 3"
+      "eslint": ">=3"
   }
 }


### PR DESCRIPTION
cc @bbraithwaite 

I think newer NPM chokes on the version defined here. http://package-json-validator.com/ was flagging this as an error.